### PR TITLE
Add backward compatibilty for previous `Plugin` constructor (< v3.5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const {Plugin:BasePlugin} = g3wsdk.core.plugin;
 
 const Plugin = function() {
   const {name, i18n} = pluginConfig;
+  // call parent constructor (> v3.4)
   base(this, {
     name,
     service: Service,

--- a/index.js
+++ b/index.js
@@ -10,6 +10,13 @@ const Plugin = function() {
     service: Service,
     i18n
   });
+  // backward compatibility (< v3.5)
+  if (!g3wsdk.version) {
+    this.name = name;
+    g3wsdk.core.i18n.addI18nPlugin({name, config: i18n});
+    this.setService(Service);
+    this.config = this.getConfig();
+  }
   //check if plugin is related to current project by gid
   if (this.registerPlugin(this.config.gid)) this.service.init(this.config);
   // need to be call to hide loading icon on map


### PR DESCRIPTION
Add the following check after calling `super()` constructor in order to allow a minimal backward compatibility with previous releases of g3w-client (< v3.5):

```js
const Plugin = function() {
  const {name, i18n} = pluginConfig;

  // call parent constructor (> v3.4)
  base(this, {
    name,
    service: Service,
    i18n
  });

  // backward compatibility (< v3.5)
  if (!g3wsdk.version) {
    this.name = name;
    g3wsdk.core.i18n.addI18nPlugin({name, config: i18n});
    this.setService(Service);
    this.config = this.getConfig();
  }

...

}
```

related to: https://github.com/g3w-suite/g3w-client/pull/119

close: https://github.com/g3w-suite/g3w-client-plugin-skeleton/issues/2